### PR TITLE
download resume button color updated to grey

### DIFF
--- a/src/components/shared/AppBanner.vue
+++ b/src/components/shared/AppBanner.vue
@@ -52,7 +52,7 @@ export default {
 				<a
 					download="Venkatesh-Bishu-Resume.pdf"
 					href="/files/resume.pdf"
-					class="flex justify-center items-center w-36 sm:w-48 mb-6 sm:mb-0 text-lg border border-red-200 dark:border-ternary-dark py-2.5 sm:py-3 shadow-lg rounded-lg bg-red-50 focus:ring-1 focus:ring-red-900 hover:bg-red-500 dark:hover:bg-red-400 text-gray-400 hover:text-white duration-500"
+					class="flex justify-center items-center w-36 sm:w-48 mb-6 sm:mb-0 text-lg border border-red-200 dark:border-ternary-dark py-2.5 sm:py-3 shadow-lg rounded-lg bg-red-50 focus:ring-1 focus:ring-red-600 hover:bg-red-500 dark:hover:bg-red-400 text-gray-500 hover:text-white duration-500"
 					aria-label="Download Resume"
 				>
 					<i


### PR DESCRIPTION
The download button color class changed from `text-gray-400` to`text-gray-500` in home page banner section.